### PR TITLE
Do not force the provider to 'rabbitmqctl'

### DIFF
--- a/manifests/hs_rabbitmq.pp
+++ b/manifests/hs_rabbitmq.pp
@@ -21,19 +21,15 @@ class  veritas_hyperscale::hs_rabbitmq (
   rabbitmq_user { 'hyperscale':
     admin    => true,
     password => $password,
-    provider => 'rabbitmqctl',
   }
 
   rabbitmq_user_permissions { "hyperscale@/":
     configure_permission => '.*',
     write_permission     => '.*',
     read_permission      => '.*',
-    provider             => 'rabbitmqctl',
   }
 
-  rabbitmq_vhost { '/':
-    provider => 'rabbitmqctl',
-  }
+  rabbitmq_vhost { '/': }
 
 # === Master
 #  ::openstacklib::messaging::rabbitmq {'vrts_hyperscale':


### PR DESCRIPTION
There is no need to force the provider to 'rabbitmqctl' as the
puppet-rabbitmq module only has that as a provider.
We need to allow the operator to override the provider so
we can use this manifest with custom tags and a noop provider
to run inside containers.